### PR TITLE
fix: update deps; show keys and addr

### DIFF
--- a/app/components/ComponentWithWasm.tsx
+++ b/app/components/ComponentWithWasm.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { SpendKey } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
-import React, { useEffect, useMemo, useState } from "react";
+import {
+  Address,
+  FullViewingKey,
+  SpendKey,
+} from "@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb";
+import { bech32mAddress } from "@penumbra-zone/bech32m/penumbra";
+
+import React, { useEffect, useState } from "react";
 
 const importWasmKeys = import("@penumbra-zone/wasm/keys");
 
@@ -10,18 +16,47 @@ export const ComponentWithWasm = () => {
     typeof importWasmKeys
   > | null>(null);
   const [seedPhrase] = useState(
-    "benefit cherry cannon tooth exhibit law avocado spare tooth that amount pumpkin scene foil tape mobile shine apology add crouch situate sun business explain",
+    "benefit cherry cannon tooth exhibit law avocado spare tooth that amount pumpkin scene foil tape mobile shine apology add crouch situate sun business explain"
   );
   const [spendKey, setSpendKey] = useState(new SpendKey());
+  const [viewingKey, setViewingKey] = useState(new FullViewingKey());
+  const [address, setAddress] = useState(new Address());
+  const [bech32, setBech32] = useState("");
   useEffect(() => {
     (async () => {
       loadWasmKeys(await importWasmKeys);
     })();
   }, [loadWasmKeys]);
+
   useEffect(() => {
     if (!wasmKeys) return;
     const spendKey = wasmKeys.generateSpendKey(seedPhrase);
     setSpendKey(spendKey);
+    const viewingKey = wasmKeys.getFullViewingKey(spendKey);
+    const address = wasmKeys.getAddressByIndex(viewingKey, 0);
+    const bech = bech32mAddress(address);
+
+    setViewingKey(viewingKey);
+    setAddress(address);
+    setBech32(bech);
   }, [wasmKeys, seedPhrase, setSpendKey]);
-  return <>{spendKey?.toJsonString()}</>;
+
+  return (
+    <div className="flex flex-col bg-gray-800 p-4 rounded-lg space-y-4">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-bold">Spend Key</h2>
+        <p className="max-w-4xl break-all">{JSON.stringify(spendKey)}</p>
+      </div>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-bold">Viewing Key</h2>
+        <p className="max-w-4xl break-all">{JSON.stringify(viewingKey)}</p>
+      </div>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-bold">Address</h2>
+        <p className="max-w-4xl break-all">{JSON.stringify(address)}</p>
+        <h2 className="text-lg font-bold">Bech32</h2>
+        {address && bech32 && <p className="max-w-4xl break-all">{bech32}</p>}
+      </div>
+    </div>
+  );
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,115 +1,14 @@
-import Image from "next/image";
-
 import { ComponentWithWasm } from "./components/ComponentWithWasm";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
-        <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
-          Get started by editing&nbsp;
-          <code className="font-mono font-bold">app/page.tsx</code>
-          <ComponentWithWasm />
+      <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm space-y-4">
+        <p className="flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
+          Check out ComponentWithWasm to see how to use the Penumbra WASM
+          bindings
         </p>
-        <div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:h-auto lg:w-auto lg:bg-none">
-          <a
-            className="pointer-events-none flex place-items-center gap-2 p-8 lg:pointer-events-auto lg:p-0"
-            href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            By{" "}
-            <Image
-              src="/vercel.svg"
-              alt="Vercel Logo"
-              className="dark:invert"
-              width={100}
-              height={24}
-              priority
-            />
-          </a>
-        </div>
-      </div>
-
-      <div className="relative flex place-items-center before:absolute before:h-[300px] before:w-full sm:before:w-[480px] before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full sm:after:w-[240px] after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 before:lg:h-[360px] z-[-1]">
-        <Image
-          className="relative dark:drop-shadow-[0_0_0.3rem_#ffffff70] dark:invert"
-          src="/next.svg"
-          alt="Next.js Logo"
-          width={180}
-          height={37}
-          priority
-        />
-      </div>
-
-      <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left">
-        <a
-          href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Docs{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            Find in-depth information about Next.js features and API.
-          </p>
-        </a>
-
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Learn{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            Learn about Next.js in an interactive course with&nbsp;quizzes!
-          </p>
-        </a>
-
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Templates{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50`}>
-            Explore starter templates for Next.js.
-          </p>
-        </a>
-
-        <a
-          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={`mb-3 text-2xl font-semibold`}>
-            Deploy{" "}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className={`m-0 max-w-[30ch] text-sm opacity-50 text-balance`}>
-            Instantly deploy your Next.js site to a shareable URL with Vercel.
-          </p>
-        </a>
+        <ComponentWithWasm />
       </div>
     </main>
   );

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@buf/penumbra-zone_penumbra.bufbuild_es": "1.8.0-20240331004851-c3b058e666bc.2",
+    "@penumbra-zone/bech32m": "^17.0.0",
+    "@penumbra-zone/protobuf": "^10.1.0",
     "@penumbra-zone/wasm": "^4.0.0",
     "next": "14.1.0",
+    "penumbra": "link:@penumbra-zone/bech32m/penumbra",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,21 @@ importers:
 
   .:
     dependencies:
-      '@buf/penumbra-zone_penumbra.bufbuild_es':
-        specifier: 1.8.0-20240331004851-c3b058e666bc.2
-        version: 1.8.0-20240331004851-c3b058e666bc.2(@bufbuild/protobuf@1.8.0)
+      '@penumbra-zone/bech32m':
+        specifier: ^17.0.0
+        version: 17.0.0(@penumbra-zone/protobuf@10.1.0(@bufbuild/protobuf@1.8.0))
+      '@penumbra-zone/protobuf':
+        specifier: ^10.1.0
+        version: 10.1.0(@bufbuild/protobuf@1.8.0)
       '@penumbra-zone/wasm':
         specifier: ^4.0.0
         version: 4.0.0(@buf/cosmos_ibc.bufbuild_es@1.8.0-20230913112312-7ab44ae956a0.2(@bufbuild/protobuf@1.8.0))(@buf/cosmos_ibc.connectrpc_es@1.4.0-20240327103030-e2006674271c.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.8.0)))(@buf/penumbra-zone_penumbra.bufbuild_es@1.8.0-20240331004851-c3b058e666bc.2(@bufbuild/protobuf@1.8.0))(@buf/penumbra-zone_penumbra.connectrpc_es@1.4.0-20240331004851-c3b058e666bc.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.8.0)))(@bufbuild/protobuf@1.8.0)
       next:
         specifier: 14.1.0
         version: 14.1.0(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      penumbra:
+        specifier: link:@penumbra-zone/bech32m/penumbra
+        version: link:@penumbra-zone/bech32m/penumbra
       react:
         specifier: ^18.3.0
         version: 18.3.0
@@ -375,6 +381,11 @@ packages:
   '@penumbra-zone/bech32@2.0.0':
     resolution: {integrity: sha512-SDR2Zg5PpcFmNuW+4ec3igS7Ud2gfvcWBm4dEqSAnR0SnAzk+RrCWRS1lOO6RssJy6GfFkHe2wbmuS6yvsCBxw==}
 
+  '@penumbra-zone/bech32m@17.0.0':
+    resolution: {integrity: sha512-/g1ZAE91VvJC/weC08GN5ZrW93671GD+fZCdc68VLho2GdMk4TX4PC2be+Mjem4r2gDlhDLE1Ecns+bpzI+5Sg==}
+    peerDependencies:
+      '@penumbra-zone/protobuf': 10.1.0
+
   '@penumbra-zone/constants@3.0.0':
     resolution: {integrity: sha512-EVi/PFC+AumsvA7q9TAV+7jVdqvWZkU8LxS2L06JFKcK6unhffuRjncW1UtrB5xYob1iL6/TRyNceS3eFxtdoA==}
     peerDependencies:
@@ -390,6 +401,11 @@ packages:
   '@penumbra-zone/keys@1.0.0':
     resolution: {integrity: sha512-9LIXfLN3ixLDYwsS+LED4JI0SwgUN4vGYkDoHp0qsqlqcqh5vEvCL4/9+XH8XOgRwtG7SCkYZB5d9rmKVEtjGw==}
     hasBin: true
+
+  '@penumbra-zone/protobuf@10.1.0':
+    resolution: {integrity: sha512-SB5EWdxTTkwFET/cvGoeuhS4CjwuTas/mqgaWppLytF6KR8rhVXZYIoDt2pgmormHEDkh6hc+aCUXPX7QIX70A==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
 
   '@penumbra-zone/types@2.0.1':
     resolution: {integrity: sha512-DpiYbtCFfywfmE2HN3bSuA+/OmDEPNUQqvMTQSu07O/QleKyEA9wxX18MrP4XimqXKALEFS+ufVqBIR5SvX82g==}
@@ -2133,6 +2149,11 @@ snapshots:
     dependencies:
       bech32: 2.0.0
 
+  '@penumbra-zone/bech32m@17.0.0(@penumbra-zone/protobuf@10.1.0(@bufbuild/protobuf@1.8.0))':
+    dependencies:
+      '@penumbra-zone/protobuf': 10.1.0(@bufbuild/protobuf@1.8.0)
+      bech32: 2.0.0
+
   '@penumbra-zone/constants@3.0.0(@buf/penumbra-zone_penumbra.bufbuild_es@1.8.0-20240331004851-c3b058e666bc.2(@bufbuild/protobuf@1.8.0))(@bufbuild/protobuf@1.8.0)':
     dependencies:
       '@buf/penumbra-zone_penumbra.bufbuild_es': 1.8.0-20240331004851-c3b058e666bc.2(@bufbuild/protobuf@1.8.0)
@@ -2147,6 +2168,10 @@ snapshots:
 
   '@penumbra-zone/keys@1.0.0':
     optional: true
+
+  '@penumbra-zone/protobuf@10.1.0(@bufbuild/protobuf@1.8.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.8.0
 
   '@penumbra-zone/types@2.0.1(@buf/cosmos_ibc.bufbuild_es@1.8.0-20230913112312-7ab44ae956a0.2(@bufbuild/protobuf@1.8.0))(@buf/cosmos_ibc.connectrpc_es@1.4.0-20240327103030-e2006674271c.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.8.0)))(@buf/penumbra-zone_penumbra.bufbuild_es@1.8.0-20240331004851-c3b058e666bc.2(@bufbuild/protobuf@1.8.0))(@buf/penumbra-zone_penumbra.connectrpc_es@1.4.0-20240331004851-c3b058e666bc.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.8.0)))(@bufbuild/protobuf@1.8.0)':
     dependencies:
@@ -2638,8 +2663,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.1(eslint@8.57.0)
@@ -2657,13 +2682,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -2674,18 +2699,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -2695,7 +2720,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
The example was not working before these changes.

```shell
 WARN  GET https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.7.2-20221020125208-34d970b699f8.1.tgz error (ENOTFOUND). Will retry in 10 seconds. 2 retries left.
 WARN  GET https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.7.2-20240327103030-e2006674271c.1.tgz error (ENOTFOUND). Will retry in 10 seconds. 2 retries left.
....
```

Update deps to use `@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb` in place of old style `@buf/` import.

Displayed keys, address and bech32 address on screen.